### PR TITLE
Throw Errors when fetch fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,11 @@ This code is available as open source under the terms of the [Apache v2.0 Licens
 
 This is created and maintained with love by [FusionAuth](https://fusionauth.io), the customer authentication and
 authorization platform that makes developers' lives awesome.
+
+# Changelog
+
+## 2.1.0
+- Components will now throw an `Error` if the fetch of the `url` fails. This is to prevent silent failures when the URL is wrong or the server is down. 
+
+## 2.0.0
+- Update to be compatible with Astro 4

--- a/components/RemoteCode.astro
+++ b/components/RemoteCode.astro
@@ -37,7 +37,6 @@ export interface Props {
 const { url, lang = 'plaintext', tags, title, ...rest } = Astro.props;
 
 const extractCode = async (url: string, tags?: string): Promise<string> => {
-
   const remoteResponse = await fetch(url);
 
   if (remoteResponse.ok) {
@@ -55,7 +54,6 @@ const extractCode = async (url: string, tags?: string): Promise<string> => {
   } else {
     throw new Error(`Failed to fetch remote code at [${url}], Reason: [${await remoteResponse.text()}]`);
   }
-
 };
 
 const remoteSelectedCode = await extractCode(url, tags);

--- a/components/RemoteCode.astro
+++ b/components/RemoteCode.astro
@@ -37,26 +37,28 @@ export interface Props {
 const { url, lang = 'plaintext', tags, title, ...rest } = Astro.props;
 
 const extractCode = async (url: string, tags?: string): Promise<string> => {
+
   const remoteResponse = await fetch(url);
-  const remoteCode = await remoteResponse.text();
 
-  if ((tags !== undefined) && (tags !== '')) {
-    return selectTagged(remoteCode, tags);
+  if (remoteResponse.ok) {
+    const remoteCode = await remoteResponse.text();
+
+    if ((tags !== undefined) && (tags !== '')) {
+      return selectTagged(remoteCode, tags);
+    }
+
+    const matchLines = url.match(/.*#L(\d+)(-L(\d+))?$/);
+    if ((matchLines !== null) && (matchLines.length > 0)) {
+      return selectLines(remoteCode, matchLines[1] as number, matchLines[3] as number);
+    }
+    return remoteCode.trim();
+  } else {
+    throw new Error(`Failed to fetch remote code at [${url}], Reason: [${await remoteResponse.text()}]`);
   }
 
-  const matchLines = url.match(/.*#L(\d+)(-L(\d+))?$/);
-  if ((matchLines !== null) && (matchLines.length > 0)) {
-    return selectLines(remoteCode, matchLines[1] as number, matchLines[3] as number);
-  }
-  return remoteCode.trim();
 };
 
-let remoteSelectedCode = 'not available';
-try {
-  remoteSelectedCode = await extractCode(url, tags);
-} catch (e) {
-  console.log('Couldn\'t retrieve remote code', e);
-}
+const remoteSelectedCode = await extractCode(url, tags);
 
 function selectTagged (content: string, tags: string): string {
   const lines = content.split('\n');

--- a/components/RemoteValue/RemoteValue.astro
+++ b/components/RemoteValue/RemoteValue.astro
@@ -85,7 +85,6 @@ if (response.ok) {
   throw new Error(`Failed to fetch remote value at [${url}], Reason: [${response.statusText}]`);
 }
 
-
 // Using the selector to look up the value
 // If you don't provide a selector, the entire file will be returned
 if ((value !== null) && (selector !== null)) {

--- a/components/RemoteValue/RemoteValue.astro
+++ b/components/RemoteValue/RemoteValue.astro
@@ -75,20 +75,21 @@ const { url, selector, parser, default: defaultValue = 'unknown' } = Astro.props
 // Value that will be rendered
 let value;
 
-try {
-  /**
-   * @link https://docs.astro.build/en/guides/data-fetching/
-   */
-  const response = await fetch(url);
+/**
+ * @link https://docs.astro.build/en/guides/data-fetching/
+ */
+const response = await fetch(url);
+if (response.ok) {
   value = await response.text();
+} else {
+  throw new Error(`Failed to fetch remote value at [${url}], Reason: [${response.statusText}]`);
+}
 
-  // Using the selector to look up the value
-  // If you don't provide a selector, the entire file will be returned
-  if ((value !== null) && (selector !== null)) {
-    value = parse(url, value, selector, parser);
-  }
-} catch (e) {
-  console.error(`Error retrieving remote value at ${url}`, selector, e);
+
+// Using the selector to look up the value
+// If you don't provide a selector, the entire file will be returned
+if ((value !== null) && (selector !== null)) {
+  value = parse(url, value, selector, parser);
 }
 
 // Default value

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fusionauth/astro-components",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fusionauth/astro-components",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "apache",
       "dependencies": {
         "jsonpath-plus": "^7.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/astro-components",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Pull in values from remote JSON files or remote code blocks at build time.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
The components would fail silently if the url could not be found and place a 404: Not found or "undefined" in the content, potentially when people not realize in CICD scenarios. This will fail the build at build time and make a big error on the screen at dev time so that developers know their URL could not be resolved.

<img width="1262" alt="Screenshot 2024-04-25 at 5 32 06 PM" src="https://github.com/FusionAuth/fusionauth-astro-components/assets/11809481/d9e5ae2a-3fe4-4329-b7d5-0a138ecc126f">
